### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts (2026-06-29)

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,62 @@
+# Repository: LazyOwn
+
+**Description:** LazyOwn RedTeam/APT Framework is the first RedTeam Framework with an AI-powered C&C, featuring rootkits to conceal campaigns, undetectable malleable implants compatible with Windows/Linux/Mac OSX, and self-configuring backdoors. With its Web interface and powerful Console Client, it is the best combination for your Autonomous RedTeam/APT campaigns.
+
+| Metric | Value |
+|--------|-------|
+| ⭐ Stars | 213 |
+| 📥 Clones (last 14 days) | 518 |
+| 🟢 Open Issues | 2 |
+| 📋 Total Issues | 4 |
+| 🛡 Dependabot Open Alerts | 35 |
+| 🔍 CodeScan Open Alerts | 3 |
+
+## Issues
+- [#84](./issue_84.md) - Lazynmap failing to execute (closed)
+- [#30](./issue_30.md) - Please remove ngrok as a tunneling option as this tool violates the terms of service (closed)
+- [#17](./issue_17.md) - Fix code scanning alert - Flask app is run in debug mode (closed)
+- [#16](./issue_16.md) - Fix code scanning alert - Information exposure through an exception (closed)
+
+## Dependabot Alerts
+- [Dependabot #44](./dependabot/alert_44.md) - msgpack (high) - open
+- [Dependabot #43](./dependabot/alert_43.md) - pypdf (medium) - open
+- [Dependabot #42](./dependabot/alert_42.md) - pypdf (medium) - open
+- [Dependabot #41](./dependabot/alert_41.md) - pypdf (medium) - open
+- [Dependabot #40](./dependabot/alert_40.md) - pypdf (medium) - open
+- [Dependabot #39](./dependabot/alert_39.md) - pypdf (medium) - open
+- [Dependabot #38](./dependabot/alert_38.md) - pypdf (medium) - open
+- [Dependabot #37](./dependabot/alert_37.md) - cryptography (high) - open
+- [Dependabot #36](./dependabot/alert_36.md) - pypdf (medium) - open
+- [Dependabot #35](./dependabot/alert_35.md) - pypdf (medium) - open
+- [Dependabot #34](./dependabot/alert_34.md) - torch (low) - open
+- [Dependabot #33](./dependabot/alert_33.md) - torch (low) - open
+- [Dependabot #32](./dependabot/alert_32.md) - pypdf (medium) - open
+- [Dependabot #31](./dependabot/alert_31.md) - pypdf (medium) - open
+- [Dependabot #30](./dependabot/alert_30.md) - pypdf (medium) - open
+- [Dependabot #29](./dependabot/alert_29.md) - pypdf (medium) - open
+- [Dependabot #28](./dependabot/alert_28.md) - pypdf (medium) - open
+- [Dependabot #27](./dependabot/alert_27.md) - cryptography (medium) - open
+- [Dependabot #26](./dependabot/alert_26.md) - pypdf (medium) - open
+- [Dependabot #25](./dependabot/alert_25.md) - pypdf (medium) - open
+- [Dependabot #24](./dependabot/alert_24.md) - pypdf (medium) - open
+- [Dependabot #23](./dependabot/alert_23.md) - pypdf (medium) - open
+- [Dependabot #22](./dependabot/alert_22.md) - pypdf (medium) - open
+- [Dependabot #21](./dependabot/alert_21.md) - pypdf (medium) - open
+- [Dependabot #20](./dependabot/alert_20.md) - pypdf (low) - open
+- [Dependabot #19](./dependabot/alert_19.md) - pypdf (medium) - open
+- [Dependabot #18](./dependabot/alert_18.md) - pypdf (medium) - open
+- [Dependabot #17](./dependabot/alert_17.md) - pypdf (medium) - open
+- [Dependabot #16](./dependabot/alert_16.md) - pypdf (medium) - open
+- [Dependabot #15](./dependabot/alert_15.md) - pypdf (low) - open
+- [Dependabot #14](./dependabot/alert_14.md) - pypdf (low) - open
+- [Dependabot #13](./dependabot/alert_13.md) - pypdf (medium) - open
+- [Dependabot #12](./dependabot/alert_12.md) - pypdf (medium) - open
+- [Dependabot #11](./dependabot/alert_11.md) - pypdf (medium) - open
+- [Dependabot #7](./dependabot/alert_7.md) - paramiko (low) - open
+
+## Code Scanning Alerts
+- [CodeScan #767](./codescan/alert_767.md) - py/bind-socket-all-network-interfaces (error) - open
+- [CodeScan #766](./codescan/alert_766.md) - py/bind-socket-all-network-interfaces (error) - open
+- [CodeScan #765](./codescan/alert_765.md) - py/bind-socket-all-network-interfaces (error) - open
+
+Total issues downloaded: 4

--- a/issues/codescan/alert_765.md
+++ b/issues/codescan/alert_765.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #765: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/765
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/codescan/alert_766.md
+++ b/issues/codescan/alert_766.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #766: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/766
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/codescan/alert_767.md
+++ b/issues/codescan/alert_767.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #767: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/767
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/dependabot/alert_11.md
+++ b/issues/dependabot/alert_11.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #11: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2025-62707
+- **Created:** 2026-06-07T17:50:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/11
+
+## Summary
+pypdf possibly loops infinitely when reading DCT inline images without EOF marker
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires parsing the content stream of a page which has an inline image using the DCTDecode filter.
+
+### Patches
+This has been fixed in [pypdf==6.1.3](https://github.com/py-pdf/pypdf/releases/tag/6.1.3).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3501](https://github.com/py-pdf/pypdf/pull/3501).

--- a/issues/dependabot/alert_12.md
+++ b/issues/dependabot/alert_12.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #12: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2025-62708
+- **Created:** 2026-06-07T17:50:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/12
+
+## Summary
+pypdf can exhaust RAM via manipulated LZWDecode streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires parsing the content stream of a page using the LZWDecode filter.
+
+### Patches
+This has been fixed in [pypdf==6.1.3](https://github.com/py-pdf/pypdf/releases/tag/6.1.3).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3502](https://github.com/py-pdf/pypdf/pull/3502).

--- a/issues/dependabot/alert_13.md
+++ b/issues/dependabot/alert_13.md
@@ -1,0 +1,27 @@
+# Dependabot Alert #13: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2025-66019
+- **Created:** 2026-06-07T17:50:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/13
+
+## Summary
+pypdf's LZWDecode streams be manipulated to exhaust RAM
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to a memory usage of up to 1 GB per stream. This requires parsing the content stream of a page using the LZWDecode filter.
+
+This is a follow up to [GHSA-jfx9-29x2-rv3j](https://github.com/py-pdf/pypdf/security/advisories/GHSA-jfx9-29x2-rv3j) to align the default limit with the one for *zlib*.
+
+### Patches
+This has been fixed in [pypdf==6.4.0](https://github.com/py-pdf/pypdf/releases/tag/6.4.0).
+
+### Workarounds
+If users cannot upgrade yet, use the line below to overwrite the default in their code:
+
+```python
+pypdf.filters.LZW_MAX_OUTPUT_LENGTH = 75_000_000
+```

--- a/issues/dependabot/alert_14.md
+++ b/issues/dependabot/alert_14.md
@@ -1,0 +1,37 @@
+# Dependabot Alert #14: pypdf
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2026-22690
+- **Created:** 2026-06-07T17:50:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/14
+
+## Summary
+pypdf has possible long runtimes for missing /Root object with large /Size values
+
+## Description
+### Impact
+An attacker who exploits this vulnerability can craft a PDF which leads to possibly long runtimes for actually invalid files. This can be achieved by omitting the `/Root` entry in the trailer, while using a rather large `/Size` value. Only the non-strict reading mode is affected.
+
+### Patches
+This has been fixed in [pypdf==6.6.0](https://github.com/py-pdf/pypdf/releases/tag/6.6.0).
+
+### Workarounds
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+
+# Instead of
+reader = PdfReader("file.pdf")
+# use the strict mode:
+reader = PdfReader("file.pdf", strict=True)
+
+# Instead of
+writer = PdfWriter(clone_from="file.pdf")
+# use an explicit strict reader:
+writer = PdfWriter(clone_from=PdfReader("file.pdf", strict=True))
+```
+
+### Resources
+This issue has been fixed in #3594.

--- a/issues/dependabot/alert_15.md
+++ b/issues/dependabot/alert_15.md
@@ -1,0 +1,37 @@
+# Dependabot Alert #15: pypdf
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2026-22691
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/15
+
+## Summary
+pypdf has possible long runtimes for malformed startxref
+
+## Description
+### Impact
+An attacker who exploits this vulnerability can craft a PDF which leads to possibly long runtimes for invalid `startxref` entries. When rebuilding the cross-reference table, PDF files with lots of whitespace characters become problematic. Only the non-strict reading mode is affected.
+
+### Patches
+This has been fixed in [pypdf==6.6.0](https://github.com/py-pdf/pypdf/releases/tag/6.6.0).
+
+### Workarounds
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+
+# Instead of
+reader = PdfReader("file.pdf")
+# use the strict mode:
+reader = PdfReader("file.pdf", strict=True)
+
+# Instead of
+writer = PdfWriter(clone_from="file.pdf")
+# use an explicit strict reader:
+writer = PdfWriter(clone_from=PdfReader("file.pdf", strict=True))
+```
+
+### Resources
+This issue has been fixed in #3594.

--- a/issues/dependabot/alert_16.md
+++ b/issues/dependabot/alert_16.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #16: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-24688
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/16
+
+## Summary
+pypdf has possible Infinite Loop when processing outlines/bookmarks
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires accessing the outlines/bookmarks.
+
+### Patches
+
+This has been fixed in [pypdf 6.6.2](https://github.com/py-pdf/pypdf/releases/tag/6.6.2).
+
+### Workarounds
+
+If projects cannot upgrade yet, consider applying the changes from PR [#3610](https://github.com/py-pdf/pypdf/pull/3610).

--- a/issues/dependabot/alert_17.md
+++ b/issues/dependabot/alert_17.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #17: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-27024
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/17
+
+## Summary
+pypdf has a possible infinite loop when processing TreeObject
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires accessing the children of a `TreeObject`, for example as part of outlines.
+
+### Patches
+
+This has been fixed in [pypdf==6.7.1](https://github.com/py-pdf/pypdf/releases/tag/6.7.1).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3645](https://github.com/py-pdf/pypdf/pull/3645).

--- a/issues/dependabot/alert_18.md
+++ b/issues/dependabot/alert_18.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #18: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-27025
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/18
+
+## Summary
+pypdf has possible long runtimes/large memory usage for large /ToUnicode streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes and large memory consumption. This requires parsing the `/ToUnicode` entry of a font with unusually large values, for example during text extraction.
+
+### Patches
+
+This has been fixed in [pypdf==6.7.1](https://github.com/py-pdf/pypdf/releases/tag/6.7.1).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3646](https://github.com/py-pdf/pypdf/pull/3646).

--- a/issues/dependabot/alert_19.md
+++ b/issues/dependabot/alert_19.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #19: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-27026
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/19
+
+## Summary
+pypdf possibly has long runtimes for malformed FlateDecode streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires a malformed `/FlateDecode` stream, where the byte-by-byte decompression is used.
+
+### Patches
+
+This has been fixed in [pypdf==6.7.1](https://github.com/py-pdf/pypdf/releases/tag/6.7.1).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3644](https://github.com/py-pdf/pypdf/pull/3644).

--- a/issues/dependabot/alert_20.md
+++ b/issues/dependabot/alert_20.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #20: pypdf
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2026-27628
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/20
+
+## Summary
+pypdf has a possible infinite loop when loading circular /Prev entries in cross-reference streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires reading the file.
+
+### Patches
+
+This has been fixed in [pypdf==6.7.2](https://github.com/py-pdf/pypdf/releases/tag/6.7.2).
+
+### Workarounds
+
+If users cannot upgrade yet, consider applying the changes from PR [#3655](https://github.com/py-pdf/pypdf/pull/3655).

--- a/issues/dependabot/alert_21.md
+++ b/issues/dependabot/alert_21.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #21: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-27888
+- **Created:** 2026-06-07T17:50:22Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/21
+
+## Summary
+pypdf: Manipulated FlateDecode XFA streams can exhaust RAM
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to the RAM being exhausted. This requires accessing the `xfa` property of a reader or writer and the corresponding stream being compressed using `/FlateDecode`.
+
+### Patches
+This has been fixed in [pypdf==6.7.3](https://github.com/py-pdf/pypdf/releases/tag/6.7.3).
+
+### Workarounds
+If projects cannot upgrade yet, consider applying the changes from PR [#3658](https://github.com/py-pdf/pypdf/pull/3658).

--- a/issues/dependabot/alert_22.md
+++ b/issues/dependabot/alert_22.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #22: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-28351
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/22
+
+## Summary
+pypdf: Manipulated RunLengthDecode streams can exhaust RAM
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires parsing the content stream using the RunLengthDecode filter.
+
+### Patches
+This has been fixed in [pypdf==6.7.4](https://github.com/py-pdf/pypdf/releases/tag/6.7.4).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3664](https://github.com/py-pdf/pypdf/pull/3664).

--- a/issues/dependabot/alert_23.md
+++ b/issues/dependabot/alert_23.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #23: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-28804
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/23
+
+## Summary
+pypdf vulnerable to inefficient decoding of ASCIIHexDecode streams
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires accessing a stream which uses the `/ASCIIHexDecode` filter.
+
+### Patches
+This has been fixed in [pypdf==6.7.5](https://github.com/py-pdf/pypdf/releases/tag/6.7.5).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3666](https://github.com/py-pdf/pypdf/pull/3666).

--- a/issues/dependabot/alert_24.md
+++ b/issues/dependabot/alert_24.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #24: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-31826
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/24
+
+## Summary
+pypdf: manipulated stream length values can exhaust RAM
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires parsing a content stream with a rather large `/Length` value, regardless of the actual data length inside the stream.
+
+### Patches
+This has been fixed in [pypdf==6.8.0](https://github.com/py-pdf/pypdf/releases/tag/6.8.0).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3675](https://github.com/py-pdf/pypdf/pull/3675).
+
+As far as we are aware, this mostly affects reading from buffers of unknown size, as returned by `open("file.pdf", mode="rb")` for example. Passing a file path or a `BytesIO` buffer to *pypdf* instead does not seem to trigger the vulnerability.

--- a/issues/dependabot/alert_25.md
+++ b/issues/dependabot/alert_25.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #25: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-33123
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/25
+
+## Summary
+pypdf has inefficient decoding of array-based streams
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes and/or large memory usage. This requires accessing an array-based stream with lots of entries.
+
+### Patches
+This has been fixed in [pypdf==6.9.1](https://github.com/py-pdf/pypdf/releases/tag/6.9.1).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3686](https://github.com/py-pdf/pypdf/pull/3686).

--- a/issues/dependabot/alert_26.md
+++ b/issues/dependabot/alert_26.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #26: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-33699
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/26
+
+## Summary
+pypdf: Possible infinite loop during recovery attempts in DictionaryObject.read_from_stream
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires reading a file in non-strict mode.
+
+### Patches
+
+This has been fixed in [pypdf==6.9.2](https://github.com/py-pdf/pypdf/releases/tag/6.9.2).
+
+### Workarounds
+
+If users cannot upgrade yet, consider applying the changes from PR [#3693](https://github.com/py-pdf/pypdf/pull/3693).

--- a/issues/dependabot/alert_27.md
+++ b/issues/dependabot/alert_27.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #27: cryptography
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-39892
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/27
+
+## Summary
+Cryptography vulnerable to buffer overflow if non-contiguous buffers were passed to APIs
+
+## Description
+If a non-contiguous buffer was passed to APIs which accepted Python buffers (e.g. `Hash.update()`), this could lead to buffer overflows. For example:
+
+```python
+h = Hash(SHA256())
+b.update(buf[::-1])
+```
+
+would read past the end of the buffer on Python >3.11

--- a/issues/dependabot/alert_28.md
+++ b/issues/dependabot/alert_28.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #28: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-40260
+- **Created:** 2026-06-07T17:50:23Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/28
+
+## Summary
+pypdf: Manipulated XMP metadata entity declarations can exhaust RAM
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires parsing the XMP metadata.
+
+### Patches
+This has been fixed in [pypdf==6.10.0](https://github.com/py-pdf/pypdf/releases/tag/6.10.0).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3724](https://github.com/py-pdf/pypdf/pull/3724).

--- a/issues/dependabot/alert_29.md
+++ b/issues/dependabot/alert_29.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #29: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-41168
+- **Created:** 2026-06-07T17:50:24Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/29
+
+## Summary
+pypdf has long runtimes for wrong size values in cross-reference and object streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires cross-reference streams with wrong large `/Size` values or object streams with wrong large `/N` values.
+
+### Patches
+
+This has been fixed in [pypdf==6.10.1](https://github.com/py-pdf/pypdf/releases/tag/6.10.1).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3733](https://github.com/py-pdf/pypdf/pull/3733).

--- a/issues/dependabot/alert_30.md
+++ b/issues/dependabot/alert_30.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #30: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-41312
+- **Created:** 2026-06-07T17:50:24Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/30
+
+## Summary
+pypdf: Manipulated FlateDecode predictor parameters can exhaust RAM
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to the RAM being exhausted. This requires accessing a stream compressed using `/FlateDecode` with a `/Predictor` unequal 1 and large predictor parameters.
+
+### Patches
+This has been fixed in [pypdf==6.10.2](https://github.com/py-pdf/pypdf/releases/tag/6.10.2).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3734](https://github.com/py-pdf/pypdf/pull/3734).

--- a/issues/dependabot/alert_31.md
+++ b/issues/dependabot/alert_31.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #31: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-41313
+- **Created:** 2026-06-07T17:50:24Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/31
+
+## Summary
+pypdf: Possible long runtimes for wrong size values in incremental mode
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires loading a PDF with a large trailer `/Size` value in incremental mode.
+
+### Patches
+This has been fixed in [pypdf==6.10.2](https://github.com/py-pdf/pypdf/releases/tag/6.10.2).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3735](https://github.com/py-pdf/pypdf/pull/3735).

--- a/issues/dependabot/alert_32.md
+++ b/issues/dependabot/alert_32.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #32: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-41314
+- **Created:** 2026-06-07T17:50:24Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/32
+
+## Summary
+pypdf: Manipulated FlateDecode image dimensions can exhaust RAM
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to the RAM being exhausted. This requires accessing an image using `/FlateDecode` with large size values.
+
+### Patches
+This has been fixed in [pypdf==6.10.2](https://github.com/py-pdf/pypdf/releases/tag/6.10.2).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3734](https://github.com/py-pdf/pypdf/pull/3734).

--- a/issues/dependabot/alert_33.md
+++ b/issues/dependabot/alert_33.md
@@ -1,0 +1,13 @@
+# Dependabot Alert #33: torch
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2025-3000
+- **Created:** 2026-06-10T22:05:59Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/33
+
+## Summary
+PyTorch is vulnerable to memory corruption through its torch.jit.script function
+
+## Description
+A vulnerability classified as critical has been found in PyTorch 2.6.0. This affects the function torch.jit.script. The manipulation leads to memory corruption. It is possible to launch the attack on the local host. The exploit has been disclosed to the public and may be used.

--- a/issues/dependabot/alert_34.md
+++ b/issues/dependabot/alert_34.md
@@ -1,0 +1,13 @@
+# Dependabot Alert #34: torch
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2025-3000
+- **Created:** 2026-06-12T02:01:04Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/34
+
+## Summary
+PyTorch is vulnerable to memory corruption through its torch.jit.script function
+
+## Description
+A vulnerability classified as critical has been found in PyTorch 2.6.0. This affects the function torch.jit.script. The manipulation leads to memory corruption. It is possible to launch the attack on the local host. The exploit has been disclosed to the public and may be used.

--- a/issues/dependabot/alert_35.md
+++ b/issues/dependabot/alert_35.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #35: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-48156
+- **Created:** 2026-06-12T19:00:07Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/35
+
+## Summary
+pypdf: Possible long runtimes for zero-only width values in cross-reference streamsuntimes for zero-only width values in cross-reference streams
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires cross-reference streams with `/W [0 0 0]` values and large `/Size` values.
+
+### Patches
+
+This has been fixed in [pypdf==6.12.0](https://github.com/py-pdf/pypdf/releases/tag/6.12.0).
+
+### Workarounds
+
+If developers are unable to upgrade their apps immediately, they should consider applying the changes from PR [#3791](https://github.com/py-pdf/pypdf/pull/3791).

--- a/issues/dependabot/alert_36.md
+++ b/issues/dependabot/alert_36.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #36: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-48155
+- **Created:** 2026-06-12T19:00:20Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/36
+
+## Summary
+pypdf: Possible large memory usage for large offsets for layout mode text
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires extracting text in layout mode with large character offsets.
+
+### Patches
+
+This has been fixed in [pypdf==6.12.0](https://github.com/py-pdf/pypdf/releases/tag/6.12.0).
+
+### Workarounds
+
+If developers are unable to immediately upgrade, they should consider applying the changes from PR [#3790](https://github.com/py-pdf/pypdf/pull/3790).

--- a/issues/dependabot/alert_37.md
+++ b/issues/dependabot/alert_37.md
@@ -1,0 +1,15 @@
+# Dependabot Alert #37: cryptography
+
+- **State:** open
+- **Severity:** high
+- **CVE:** N/A
+- **Created:** 2026-06-19T18:40:18Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/37
+
+## Summary
+Vulnerable OpenSSL included in cryptography wheels
+
+## Description
+pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in wheels prior to cryptograph 48.01 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://openssl-library.org/news/secadv/20260609.txt.
+
+If you are building cryptography source ("sdist") then you are responsible for upgrading your copy of OpenSSL. Only users installing from wheels built by the cryptography project (i.e., those distributed on PyPI) need to update their cryptography versions.

--- a/issues/dependabot/alert_38.md
+++ b/issues/dependabot/alert_38.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #38: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-49461
+- **Created:** 2026-06-19T22:06:03Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/38
+
+## Summary
+pypdf: Possible large memory usage for form XObjects during text extraction
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires extracting the text of a page which contains a form XObject with self-references.
+
+### Patches
+This has been fixed in [pypdf==6.12.2](https://github.com/py-pdf/pypdf/releases/tag/6.12.2).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3805](https://github.com/py-pdf/pypdf/pull/3805).

--- a/issues/dependabot/alert_39.md
+++ b/issues/dependabot/alert_39.md
@@ -1,0 +1,20 @@
+# Dependabot Alert #39: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-49460
+- **Created:** 2026-06-19T22:06:06Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/39
+
+## Summary
+pypdf: Inefficient decoding of FlateDecode PNG predictor streams
+
+## Description
+### Impact
+An attacker who uses this vulnerability can craft a PDF which leads to long runtimes. This requires accessing a stream which uses the `/FlateDecode` filter with a PNG predictor.
+
+### Patches
+This has been fixed in [pypdf==6.12.2](https://github.com/py-pdf/pypdf/releases/tag/6.12.2).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3806](https://github.com/py-pdf/pypdf/pull/3806).

--- a/issues/dependabot/alert_40.md
+++ b/issues/dependabot/alert_40.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #40: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-54531
+- **Created:** 2026-06-19T22:26:26Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/40
+
+## Summary
+pypdf: Possible infinite loop when processing outlines/bookmarks in writer
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires merging a file with outlines into a writer.
+
+### Patches
+
+This has been fixed in [pypdf==6.13.0](https://github.com/py-pdf/pypdf/releases/tag/6.13.0).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3830](https://github.com/py-pdf/pypdf/pull/3830).

--- a/issues/dependabot/alert_41.md
+++ b/issues/dependabot/alert_41.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #41: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-54530
+- **Created:** 2026-06-19T22:26:48Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/41
+
+## Summary
+pypdf: Possible infinite loop when retrieving fonts for layout-mode text extraction
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to an infinite loop. This requires extracting the text in layout mode.
+
+### Patches
+
+This has been fixed in [pypdf==6.13.0](https://github.com/py-pdf/pypdf/releases/tag/6.13.0).
+
+### Workarounds
+
+If you cannot upgrade yet, consider applying the changes from PR [#3830](https://github.com/py-pdf/pypdf/pull/3830).

--- a/issues/dependabot/alert_42.md
+++ b/issues/dependabot/alert_42.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #42: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** N/A
+- **Created:** 2026-06-20T08:07:14Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/42
+
+## Summary
+pypdf: Missing stream length values ignore defined limits
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage, as `MAX_DECLARED_STREAM_LENGTH` is sometimes ignored. This requires parsing a content stream without a `/Length` value.
+
+### Patches
+This has been fixed in [pypdf==6.13.3](https://github.com/py-pdf/pypdf/releases/tag/6.13.3).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3871](https://github.com/py-pdf/pypdf/pull/3871).

--- a/issues/dependabot/alert_43.md
+++ b/issues/dependabot/alert_43.md
@@ -1,0 +1,21 @@
+# Dependabot Alert #43: pypdf
+
+- **State:** open
+- **Severity:** medium
+- **CVE:** CVE-2026-48735
+- **Created:** 2026-06-20T09:41:17Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/43
+
+## Summary
+pypdf: Manipulated XMP metadata streams can exhaust RAM
+
+## Description
+### Impact
+
+An attacker who uses this vulnerability can craft a PDF which leads to large memory usage. This requires parsing large XMP metadata, possibly with lots of unnecessary elements.
+
+### Patches
+This has been fixed in [pypdf==6.12.1](https://github.com/py-pdf/pypdf/releases/tag/6.12.1).
+
+### Workarounds
+If you cannot upgrade yet, consider applying the changes from PR [#3796](https://github.com/py-pdf/pypdf/pull/3796).

--- a/issues/dependabot/alert_44.md
+++ b/issues/dependabot/alert_44.md
@@ -1,0 +1,29 @@
+# Dependabot Alert #44: msgpack
+
+- **State:** open
+- **Severity:** high
+- **CVE:** N/A
+- **Created:** 2026-06-20T15:39:20Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/44
+
+## Summary
+MessagePack for Python: Out-of-bounds read / crash on Unpacker reuse after a caught error
+
+## Description
+### Impact
+
+If the Unpacker is used repeatedly after an error occurs, the process may crash with a SEGV.
+
+If the Unpacker is used repeatedly to unpack untrusted input from external sources, it may be vulnerable to a DoS attack.
+
+### Patches
+
+v1.2.1
+
+### Workarounds
+
+Users should create a new Unpacker instead of reusing the same Unpacker after an error occurs.
+
+Applying the above patch can prevent SEGV, but reusing the Streaming Unpacker after it has encountered an error will not yield correct data. If an error occurs during Streaming Unpacking, the Stream and Streaming Unpacker should be discarded.
+
+Therefore, this is not just a workaround but the correct solution. The above patch only prevents crashes from incorrect usage.

--- a/issues/dependabot/alert_7.md
+++ b/issues/dependabot/alert_7.md
@@ -1,0 +1,13 @@
+# Dependabot Alert #7: paramiko
+
+- **State:** open
+- **Severity:** low
+- **CVE:** CVE-2026-44405
+- **Created:** 2026-06-06T17:08:16Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/7
+
+## Summary
+Paramiko rsakey.py allows the SHA-1 algorithm
+
+## Description
+In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm.

--- a/issues/issue_16.md
+++ b/issues/issue_16.md
@@ -1,0 +1,13 @@
+# Issue #16: Fix code scanning alert - Information exposure through an exception
+
+- **State:** closed
+- **Created:** 2024-06-09T07:07:45Z
+- **Updated:** 2024-06-09T07:12:42Z
+- **Labels:** None
+
+---
+
+<!-- Warning: The suggested title contains the alert rule name. This can expose security information. -->
+
+Tracking issue for:
+- [x] https://github.com/grisuno/LazyOwn/security/code-scanning/6

--- a/issues/issue_17.md
+++ b/issues/issue_17.md
@@ -1,0 +1,13 @@
+# Issue #17: Fix code scanning alert - Flask app is run in debug mode
+
+- **State:** closed
+- **Created:** 2024-06-09T07:08:21Z
+- **Updated:** 2024-06-09T07:09:28Z
+- **Labels:** None
+
+---
+
+<!-- Warning: The suggested title contains the alert rule name. This can expose security information. -->
+
+Tracking issue for:
+- [x] https://github.com/grisuno/LazyOwn/security/code-scanning/5

--- a/issues/issue_30.md
+++ b/issues/issue_30.md
@@ -1,0 +1,17 @@
+# Issue #30: Please remove ngrok as a tunneling option as this tool violates the terms of service
+
+- **State:** closed
+- **Created:** 2024-09-03T16:49:02Z
+- **Updated:** 2024-09-05T05:06:42Z
+- **Labels:** None
+
+---
+
+PM for ngrok here. This tool directly violates the ngrok Terms of Service even when used for educational purposes only. We kindly request that ngrok be removed as an option in your tool. Please consider replacing it with other options [from this list](https://github.com/anderspitman/awesome-tunneling).
+
+To learn more about how ngrok combats abuse, see https://ngrok.com/abuse and https://ngrok.com/tos .
+
+ - ngrok is not anonymous and can not be used to hide your identity.
+ - ngrok directly exposes your public IP address to anyone who sees the ngrok url you send them and in an http header.
+ - ngrok will ban your account if you use this tool.
+ - ngrok adds an interstitial page to all requests warning anyone viewing the page that the site is hosted by ngrok.

--- a/issues/issue_84.md
+++ b/issues/issue_84.md
@@ -1,0 +1,26 @@
+# Issue #84: Lazynmap failing to execute
+
+- **State:** closed
+- **Created:** 2025-01-31T17:03:11Z
+- **Updated:** 2025-02-05T03:16:37Z
+- **Labels:** None
+
+---
+
+**Describe the bug**
+When executing the `run lazynmap` command, an error is generated indicating that `No such file or directory` is present in /home/USER/LazyOwn/sessions/logs/command_/home/USER/LazyOwn/modules/lazynmap.shoutputBigBang.htb.txt
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Assign RHOST IP
+2. Execute `run lazynmap`
+
+
+**Expected behavior**
+LazyNmap should run successfully
+
+**Screenshots**
+N/A
+
+**Desktop (please complete the following information):**
+ - OS: Ubuntu 24.04.1 LTS


### PR DESCRIPTION
Automated security export generated on 20260629_013021.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Generated by `security_issue_progressive.sh`.