### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts (2026-06-29)

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,32 @@
+# Repository: LazyOwn
+
+**Description:** LazyOwn RedTeam/APT Framework is the first RedTeam Framework with an AI-powered C&C, featuring rootkits to conceal campaigns, undetectable malleable implants compatible with Windows/Linux/Mac OSX, and self-configuring backdoors. With its Web interface and powerful Console Client, it is the best combination for your Autonomous RedTeam/APT campaigns.
+
+| Metric | Value |
+|--------|-------|
+| ⭐ Stars | 213 |
+| 📥 Clones (last 14 days) | 529 |
+| 🟢 Open Issues | 5 |
+| 📋 Total Issues | 4 |
+| 🛡 Dependabot Open Alerts | 3 |
+| 🔍 CodeScan Open Alerts | 5 |
+
+## Issues
+- [#84](./issue_84.md) - Lazynmap failing to execute (closed)
+- [#30](./issue_30.md) - Please remove ngrok as a tunneling option as this tool violates the terms of service (closed)
+- [#17](./issue_17.md) - Fix code scanning alert - Flask app is run in debug mode (closed)
+- [#16](./issue_16.md) - Fix code scanning alert - Information exposure through an exception (closed)
+
+## Dependabot Alerts
+- [Dependabot #47](./dependabot/alert_47.md) - python-socketio (high) - open
+- [Dependabot #46](./dependabot/alert_46.md) - python-engineio (high) - open
+- [Dependabot #45](./dependabot/alert_45.md) - python-engineio (high) - open
+
+## Code Scanning Alerts
+- [CodeScan #776](./codescan/alert_776.md) - py/overly-large-range (warning) - open
+- [CodeScan #775](./codescan/alert_775.md) - py/overly-large-range (warning) - open
+- [CodeScan #767](./codescan/alert_767.md) - py/bind-socket-all-network-interfaces (error) - open
+- [CodeScan #766](./codescan/alert_766.md) - py/bind-socket-all-network-interfaces (error) - open
+- [CodeScan #765](./codescan/alert_765.md) - py/bind-socket-all-network-interfaces (error) - open
+
+Total issues downloaded: 4

--- a/issues/codescan/alert_765.md
+++ b/issues/codescan/alert_765.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #765: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/765
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/codescan/alert_766.md
+++ b/issues/codescan/alert_766.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #766: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/766
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/codescan/alert_767.md
+++ b/issues/codescan/alert_767.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #767: py/bind-socket-all-network-interfaces
+
+- **State:** open
+- **Severity:** error
+- **Tool:** CodeQL
+- **Created:** 2026-05-21T04:27:05Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/767
+
+## Description
+Binding a socket to all network interfaces

--- a/issues/codescan/alert_775.md
+++ b/issues/codescan/alert_775.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #775: py/overly-large-range
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T08:37:57Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/775
+
+## Description
+Overly permissive regular expression range

--- a/issues/codescan/alert_776.md
+++ b/issues/codescan/alert_776.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #776: py/overly-large-range
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-29T08:37:57Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/code-scanning/776
+
+## Description
+Overly permissive regular expression range

--- a/issues/dependabot/alert_45.md
+++ b/issues/dependabot/alert_45.md
@@ -1,0 +1,23 @@
+# Dependabot Alert #45: python-engineio
+
+- **State:** open
+- **Severity:** high
+- **CVE:** CVE-2026-48809
+- **Created:** 2026-06-29T09:59:20Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/45
+
+## Summary
+python-engineio has possible denial of service due to maximum payload size sometimes not being enforced
+
+## Description
+### Impact
+There are two specific configurations of the python-engineio server in which the size of incoming messages is not checked before the messages are loaded into memory. An attacker can take advantage of these to cause unnecessary memory allocations in the python-engineio server. The two cases are:
+
+- POST requests, when using ASGI with the long polling transport
+- WebSocket messages, when using Aiohttp with the WebSocket transport
+
+### Patches
+Version 4.13.2 addresses this issue as follows:
+
+- ASGI severs now only load the body of incoming requests into memory after the client is confirmed to be known and authenticated, and the payload size is below the maximum allowed size. Requests that do not comply with these requirements are discarded.
+- Aiohttp servers configure the maximum payload size in the underlying WebSocket layer from Aiohttp, so that large messages are discarded by Aiohttp before they are delivered to python-engineio.

--- a/issues/dependabot/alert_46.md
+++ b/issues/dependabot/alert_46.md
@@ -1,0 +1,22 @@
+# Dependabot Alert #46: python-engineio
+
+- **State:** open
+- **Severity:** high
+- **CVE:** CVE-2026-48802
+- **Created:** 2026-06-29T09:59:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/46
+
+## Summary
+python-engineio has unbound thread allocation that can cause denial of service
+
+## Description
+### Impact
+An attacker can cause the creation of unnecessary background threads in the python-engineio server by exploiting the heartbeat mechanism, which launches a thread when a new connection is received, and when the client sends a PONG packet.
+
+Note: this issue primarily affects synchronous servers. Asynchronous servers allocate background tasks instead of physical threads, which are lightweight and less likely to cause denial of service. However, the fix that was implemented was also applied to the asynchronous case.
+
+### Patches
+Version 4.13.2 addresses this issue as follows:
+
+- The initial background thread (or async task( for heartbeat management is only launched if a client passes authentication in the `connect` handler.
+- The server now ensures that there is only one background heatbeat thread (or async task) per client at a given point in time. Out of sequence PONG packets are now discarded when an active heartbeat thread is already running.

--- a/issues/dependabot/alert_47.md
+++ b/issues/dependabot/alert_47.md
@@ -1,0 +1,19 @@
+# Dependabot Alert #47: python-socketio
+
+- **State:** open
+- **Severity:** high
+- **CVE:** CVE-2026-48804
+- **Created:** 2026-06-29T09:59:21Z
+- **URL:** https://github.com/grisuno/LazyOwn/security/dependabot/47
+
+## Summary
+python-socketio: Binary attachment accumulation can cause denial of service
+
+## Description
+### Impact
+The python-socketio server stores binary `EVENT` and `ACK` messages in memory while it waits to receive their binary attachments. Once all the attachments are received, these messages are then processed. An attacker can submit a binary message and intentionally omit sending one or more of its attachments to cause the message along with the partial list of received attachments to stay in memory for a long time.
+
+### Patches
+Version 5.16.2 takes the following measures to address this issue:
+- Binary packets are only accepted from authenticated clients.
+- When a client disconnects, the server checks if there is a partial binary message being held for the client and deletes it.

--- a/issues/issue_16.md
+++ b/issues/issue_16.md
@@ -1,0 +1,13 @@
+# Issue #16: Fix code scanning alert - Information exposure through an exception
+
+- **State:** closed
+- **Created:** 2024-06-09T07:07:45Z
+- **Updated:** 2024-06-09T07:12:42Z
+- **Labels:** None
+
+---
+
+<!-- Warning: The suggested title contains the alert rule name. This can expose security information. -->
+
+Tracking issue for:
+- [x] https://github.com/grisuno/LazyOwn/security/code-scanning/6

--- a/issues/issue_17.md
+++ b/issues/issue_17.md
@@ -1,0 +1,13 @@
+# Issue #17: Fix code scanning alert - Flask app is run in debug mode
+
+- **State:** closed
+- **Created:** 2024-06-09T07:08:21Z
+- **Updated:** 2024-06-09T07:09:28Z
+- **Labels:** None
+
+---
+
+<!-- Warning: The suggested title contains the alert rule name. This can expose security information. -->
+
+Tracking issue for:
+- [x] https://github.com/grisuno/LazyOwn/security/code-scanning/5

--- a/issues/issue_30.md
+++ b/issues/issue_30.md
@@ -1,0 +1,17 @@
+# Issue #30: Please remove ngrok as a tunneling option as this tool violates the terms of service
+
+- **State:** closed
+- **Created:** 2024-09-03T16:49:02Z
+- **Updated:** 2024-09-05T05:06:42Z
+- **Labels:** None
+
+---
+
+PM for ngrok here. This tool directly violates the ngrok Terms of Service even when used for educational purposes only. We kindly request that ngrok be removed as an option in your tool. Please consider replacing it with other options [from this list](https://github.com/anderspitman/awesome-tunneling).
+
+To learn more about how ngrok combats abuse, see https://ngrok.com/abuse and https://ngrok.com/tos .
+
+ - ngrok is not anonymous and can not be used to hide your identity.
+ - ngrok directly exposes your public IP address to anyone who sees the ngrok url you send them and in an http header.
+ - ngrok will ban your account if you use this tool.
+ - ngrok adds an interstitial page to all requests warning anyone viewing the page that the site is hosted by ngrok.

--- a/issues/issue_84.md
+++ b/issues/issue_84.md
@@ -1,0 +1,26 @@
+# Issue #84: Lazynmap failing to execute
+
+- **State:** closed
+- **Created:** 2025-01-31T17:03:11Z
+- **Updated:** 2025-02-05T03:16:37Z
+- **Labels:** None
+
+---
+
+**Describe the bug**
+When executing the `run lazynmap` command, an error is generated indicating that `No such file or directory` is present in /home/USER/LazyOwn/sessions/logs/command_/home/USER/LazyOwn/modules/lazynmap.shoutputBigBang.htb.txt
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Assign RHOST IP
+2. Execute `run lazynmap`
+
+
+**Expected behavior**
+LazyNmap should run successfully
+
+**Screenshots**
+N/A
+
+**Desktop (please complete the following information):**
+ - OS: Ubuntu 24.04.1 LTS


### PR DESCRIPTION
Automated security export generated on 20260629_131848.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Generated by `security_issue_progressive.sh`.